### PR TITLE
v1.1.1

### DIFF
--- a/gelfoutput/examples/example1.go
+++ b/gelfoutput/examples/example1.go
@@ -1,3 +1,4 @@
+//go:build examples
 // +build examples
 
 package main

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goinsane/xlog
 
 go 1.13
 
-require github.com/goinsane/erf v1.1.1
+require github.com/goinsane/erf v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,7 @@ github.com/goinsane/erf v1.1.0 h1:9JmWZUexQXHrNsLKERygGr3wQCAG04bo6mS4UgXDOKo=
 github.com/goinsane/erf v1.1.0/go.mod h1:KIGOu4SVAUGC5gHe3Q/uCswZN40wwPFJ9MS924nA/AI=
 github.com/goinsane/erf v1.1.1 h1:X7HZBYI96H0yGhrK4Sxr/y1L3ZIwOXfBhqN/XLaODgc=
 github.com/goinsane/erf v1.1.1/go.mod h1:KIGOu4SVAUGC5gHe3Q/uCswZN40wwPFJ9MS924nA/AI=
+github.com/goinsane/erf v1.1.2 h1:Ai84DJXXmQPOXUXjdGVDJdYfkF/cfhAefe7i5JpQzC0=
+github.com/goinsane/erf v1.1.2/go.mod h1:KIGOu4SVAUGC5gHe3Q/uCswZN40wwPFJ9MS924nA/AI=
 gopkg.in/Graylog2/go-gelf.v2 v2.0.0-20191017102106-1550ee647df0 h1:Xg23ydYYJLmb9AK3XdcEpplHZd1MpN3X2ZeeMoBClmY=
 gopkg.in/Graylog2/go-gelf.v2 v2.0.0-20191017102106-1550ee647df0/go.mod h1:CeDeqW4tj9FrgZXF/dQCWZrBdcZWWBenhJtxLH4On2g=


### PR DESCRIPTION
- inserted '//go:build examples' into gelfoutput's example1
- updated erf version to v1.1.2
- improved methods of Severity type
- added ErrInvalidSeverity