### PR TITLE
v1.2.3

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -405,9 +405,9 @@ func (l *Logger) WithFieldMap(fieldMap map[string]interface{}) *Logger {
 	return l.WithFields(fields...)
 }
 
-// ErfError creates a new *erf.Erf by given arguments. It logs to the ERROR severity logs and returns the *erf.Erf.
-func (l *Logger) ErfError(text string) *erf.Erf {
-	return l.erfError(SeverityError, text)
+// ErfError creates a new *erf.Erf by the given argument. It logs to the ERROR severity logs and returns the *erf.Erf.
+func (l *Logger) ErfError(arg interface{}) *erf.Erf {
+	return l.erfError(SeverityError, arg)
 }
 
 // ErfErrorf creates a new *erf.Erf by given arguments. It logs to the ERROR severity logs and returns the result to call Attach method of *erf.Erf.
@@ -415,14 +415,9 @@ func (l *Logger) ErfErrorf(format string, args ...interface{}) *loggerErfResult 
 	return l.erfErrorf(SeverityError, format, args...)
 }
 
-// ErfErrorWrap creates a new *erf.Erf by given error e. It logs to the ERROR severity logs and returns the *erf.Erf.
-func (l *Logger) ErfErrorWrap(e error) *erf.Erf {
-	return l.erfErrorWrap(SeverityError, e)
-}
-
-// ErfWarning creates a new *erf.Erf by given arguments. It logs to the WARNING severity logs and returns the *erf.Erf.
-func (l *Logger) ErfWarning(text string) *erf.Erf {
-	return l.erfError(SeverityWarning, text)
+// ErfWarning creates a new *erf.Erf by the given argument. It logs to the WARNING severity logs and returns the *erf.Erf.
+func (l *Logger) ErfWarning(arg interface{}) *erf.Erf {
+	return l.erfError(SeverityWarning, arg)
 }
 
 // ErfWarningf creates a new *erf.Erf by given arguments. It logs to the WARNING severity logs and returns the result to call Attach method of *erf.Erf.
@@ -430,16 +425,16 @@ func (l *Logger) ErfWarningf(format string, args ...interface{}) *loggerErfResul
 	return l.erfErrorf(SeverityWarning, format, args...)
 }
 
-// ErfWarningWrap creates a new *erf.Erf by given error e. It logs to the WARNING severity logs and returns the *erf.Erf.
-func (l *Logger) ErfWarningWrap(e error) *erf.Erf {
-	return l.erfErrorWrap(SeverityWarning, e)
-}
-
-func (l *Logger) erfError(severity Severity, text string) *erf.Erf {
+func (l *Logger) erfError(severity Severity, arg interface{}) *erf.Erf {
 	result := &loggerErfResult{
 		l: l.Duplicate(),
 		s: severity,
-		e: erf.New(text).CopyByTop(2),
+		e: nil,
+	}
+	if e, ok := arg.(error); ok {
+		result.e = erf.Wrap(e).(*erf.Erf).CopyByTop(2)
+	} else {
+		result.e = erf.New(fmt.Sprint(arg)).CopyByTop(2)
 	}
 	return result.Attach()
 }
@@ -451,15 +446,6 @@ func (l *Logger) erfErrorf(severity Severity, format string, args ...interface{}
 		e: erf.Newf(format, args...).CopyByTop(2),
 	}
 	return result
-}
-
-func (l *Logger) erfErrorWrap(severity Severity, e error) *erf.Erf {
-	result := &loggerErfResult{
-		l: l.Duplicate(),
-		s: severity,
-		e: erf.Wrap(e).(*erf.Erf).CopyByTop(2),
-	}
-	return result.Attach()
 }
 
 type loggerErfResult struct {

--- a/xlog.go
+++ b/xlog.go
@@ -209,9 +209,9 @@ func SetOutputFlags(flags Flag) *TextOutput {
 	return defaultOutput.SetFlags(flags)
 }
 
-// ErfError creates a new *erf.Erf by given arguments. It logs to the ERROR severity logs to the default Logger and returns the *erf.Erf.
-func ErfError(text string) *erf.Erf {
-	return defaultLogger.erfError(SeverityError, text)
+// ErfError creates a new *erf.Erf by the given argument. It logs to the ERROR severity logs to the default Logger and returns the *erf.Erf.
+func ErfError(arg interface{}) *erf.Erf {
+	return defaultLogger.erfError(SeverityError, arg)
 }
 
 // ErfErrorf creates a new *erf.Erf by given arguments. It logs to the ERROR severity logs to the default Logger and the result to call Attach method of *erf.Erf.
@@ -219,24 +219,14 @@ func ErfErrorf(format string, args ...interface{}) *loggerErfResult {
 	return defaultLogger.erfErrorf(SeverityError, format, args...)
 }
 
-// ErfErrorWrap creates a new *erf.Erf by given error e. It logs to the ERROR severity logs to the default Logger and returns the *erf.Erf.
-func ErfErrorWrap(e error) *erf.Erf {
-	return defaultLogger.erfErrorWrap(SeverityError, e)
-}
-
-// ErfWarning creates a new *erf.Erf by given arguments. It logs to the WARNING severity logs to the default Logger and returns the *erf.Erf.
-func ErfWarning(text string) *erf.Erf {
-	return defaultLogger.erfError(SeverityWarning, text)
+// ErfWarning creates a new *erf.Erf by the given argument. It logs to the WARNING severity logs to the default Logger and returns the *erf.Erf.
+func ErfWarning(arg interface{}) *erf.Erf {
+	return defaultLogger.erfError(SeverityWarning, arg)
 }
 
 // ErfWarningf creates a new *erf.Erf by given arguments. It logs to the WARNING severity logs to the default Logger and returns the result to call Attach method of *erf.Erf.
 func ErfWarningf(format string, args ...interface{}) *loggerErfResult {
 	return defaultLogger.erfErrorf(SeverityWarning, format, args...)
-}
-
-// ErfWarningWrap creates a new *erf.Erf by given error e. It logs to the WARNING severity logs to the default Logger and returns the *erf.Erf.
-func ErfWarningWrap(e error) *erf.Erf {
-	return defaultLogger.erfErrorWrap(SeverityWarning, e)
 }
 
 // Reset resets the default Logger and the default Output.


### PR DESCRIPTION
- removed Logger.ErfErrorWrap, Logger.ErfWarningWrap methods
- removed ErfErrorWrap, ErfWarningWrap functions
- changed ErfError and ErfWarning methods and functions to handle errors or other args